### PR TITLE
Define returns none

### DIFF
--- a/starfall_bot/info_service.py
+++ b/starfall_bot/info_service.py
@@ -15,4 +15,8 @@ class InfoService:
         :return: The definition of the word.
         """
         definition = self._definition_collector.get_definition(word)
-        return definition
+
+        if definition:
+            return definition
+
+        return f"I'm sorry, but I don't know the word '{word}' either."

--- a/tests/test_info_service.py
+++ b/tests/test_info_service.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import MagicMock
+
+from starfall_bot.definition_collector import DefinitionCollector
+from starfall_bot.info_service import InfoService
+
+
+class InfoServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_definition_collector = MagicMock(spec=DefinitionCollector)
+        self.test_info_service = InfoService(self.mock_definition_collector)
+
+
+class DefineTests(InfoServiceTests):
+    def test_ensuring_that_valid_definition_is_passed_on(self):
+        # Arrange
+        expected_result = "The Definition."
+        self.mock_definition_collector.get_definition.return_value = "The Definition."
+
+        # Act
+        result = self.test_info_service.define("test")
+
+        # Assert
+        self.assertEqual(expected_result, result)
+
+    def test_unknown_word_returns_unknown_message(self):
+        # Arrange
+        expected_result = "I'm sorry, but I don't know the word 'test' either."
+        self.mock_definition_collector.get_definition.return_value = None
+
+        # Act
+        result = self.test_info_service.define("test")
+
+        # Assert
+        self.assertEqual(expected_result, result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Created new tests for `info_service` and added code to ensure that the info service handles the missing definitions